### PR TITLE
[BUGFIX] Fix availability check for BE variants

### DIFF
--- a/Classes/EventListener/CheckProductAvailability.php
+++ b/Classes/EventListener/CheckProductAvailability.php
@@ -74,7 +74,7 @@ class CheckProductAvailability
             return;
         }
 
-        $compareQuantity = 0;
+        $compareQuantity = $quantity;
 
         foreach ($cartProduct->getBeVariants() as $beVariant) {
             if (


### PR DESCRIPTION
BE variants can no longer be added to the cart
if the requested amount exceeds the stock.

The old implementation set the compare quantity
to zero which was wrong as it must be the
quantity which is in the cart of the customer.