### PR TITLE
[TASK] Listen to ProcessOrderCheckStockEvent

### DIFF
--- a/Classes/EventListener/Order/Stock/ProcessOrderCheckStock.php
+++ b/Classes/EventListener/Order/Stock/ProcessOrderCheckStock.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Extcode\CartProducts\EventListener\Order\Stock;
+
+/*
+ * This file is part of the package extcode/cart-products.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Extcode\Cart\Event\ProcessOrderCheckStockEvent;
+use Extcode\CartProducts\Domain\Model\Product\Product;
+use Extcode\CartProducts\Domain\Repository\Product\ProductRepository;
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
+
+class ProcessOrderCheckStock
+{
+    public function __construct(
+        protected readonly ProductRepository $productRepository
+    ) {
+    }
+
+    public function __invoke(ProcessOrderCheckStockEvent $event): void
+    {
+        $cart = $event->getCart();
+        $cartProducts = $cart->getProducts();
+
+        foreach ($cartProducts as $cartProduct) {
+            if ($cartProduct->getProductType() !== 'CartProducts') {
+                continue;
+            }
+
+            $querySettings = $this->productRepository->createQuery()->getQuerySettings();
+            $querySettings->setRespectStoragePage(false);
+            $this->productRepository->setDefaultQuerySettings($querySettings);
+            $product = $this->productRepository->findByIdentifier($cartProduct->getProductId());
+
+            if (!$product instanceof Product || !$product->isHandleStock()) {
+                continue;
+            }
+
+            $compareQuantity = $cartProduct->getQuantity();
+
+            if (!$product->isHandleStockInVariants()) {
+                $quantityInStock = $product->getStock();
+                if ($compareQuantity > $quantityInStock) {
+                    $this->falseAvailability($event, $product->getTitle(), $product->getSku(), $quantityInStock);
+                }
+                continue;
+            }
+
+            foreach ($product->getBeVariants() as $beVariant) {
+                $quantityInStock = $beVariant->getStock();
+                if ($compareQuantity > $quantityInStock) {
+                    $this->falseAvailability($event, $product->getTitle(), $beVariant->getSku(), $quantityInStock);
+                }
+            }
+        }
+    }
+
+    protected function falseAvailability(
+        ProcessOrderCheckStockEvent $event,
+        string $title,
+        string $sku,
+        int $quantityInStock
+    ): void
+    {
+        $event->setNotAllProductsAreAvailable();
+        $event->addMessage(
+            GeneralUtility::makeInstance(
+                FlashMessage::class,
+                LocalizationUtility::translate(
+                    'tx_cart.error.stock_handling.order',
+                    'cart',
+                    [$title, $sku, $quantityInStock]
+                ),
+                '',
+                ContextualFeedbackSeverity::ERROR
+            )
+        );
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -66,6 +66,13 @@ services:
         identifier: 'cart-products--check-product-availability'
         event: Extcode\Cart\Event\CheckProductAvailabilityEvent
 
+  Extcode\CartProducts\EventListener\Order\Stock\ProcessOrderCheckStock:
+    tags:
+      - name: event.listener
+        identifier: 'cart-products--process-order-check-stock'
+        event: Extcode\Cart\Event\ProcessOrderCheckStockEvent
+
+
   Extcode\CartProducts\Reaction\UpdateStockReaction:
     tags: ['reactions.reaction']
     public: true


### PR DESCRIPTION
Allow to check the stock during the order process
by listening to the extended `ProcessOrderCheckStockEvent`.

Fixes #138