### PR TITLE
[BUGFIX] Avoid error for quantity discounts

### DIFF
--- a/Classes/Domain/Model/Product/QuantityDiscount.php
+++ b/Classes/Domain/Model/Product/QuantityDiscount.php
@@ -27,7 +27,7 @@ class QuantityDiscount extends AbstractEntity
      */
     protected int $quantity = 0;
 
-    protected FrontendUserGroup $frontendUserGroup;
+    protected ?FrontendUserGroup $frontendUserGroup = null;
 
     public function toArray(): array
     {


### PR DESCRIPTION
Allowing the FE usergroup to be null avoids the
error that otherwise occurs when adding a product
with special price to the cart.

Fixes #143